### PR TITLE
feat: set & get leverage

### DIFF
--- a/src/entities/account-information.ts
+++ b/src/entities/account-information.ts
@@ -1,3 +1,10 @@
+import { LeverageType } from "../enums/leverage.enum";
+
+/**
+ * Get basic account information including current user fee rates.
+ * 
+ * @link https://docs-api.orderly.network/#restful-api-private-get-account-information
+ */
 export interface AccountInformation {
   account_id: string;
   email: string;
@@ -5,4 +12,5 @@ export interface AccountInformation {
   tier: string;
   taker_fee_rate: number;
   maker_fee_rate: number;
+  max_leverage: LeverageType;
 }

--- a/src/enums/leverage.enum.ts
+++ b/src/enums/leverage.enum.ts
@@ -1,0 +1,6 @@
+/**
+ * Leverage can only be one of 1,2,3,4,5,10
+ *
+ * @link https://docs-api.orderly.network/#restful-api-private-update-leverage-setting
+ */
+export type LeverageType = 1 | 2 | 3 | 4 | 5 | 10;


### PR DESCRIPTION
### Changes

- added [`setLeverage`](https://docs-api.orderly.network/#restful-api-private-update-leverage-setting) to `RestClient`
- added missing [`max_leverage`](https://docs-api.orderly.network/#restful-api-private-get-account-information) field to `getInformation`
- format with the project's prettier setting 

### Example

```ts
import {RestClient} from './rest/index'

(
  async() => {
      const rest = new RestClient({})
      // { success: true, data: {}, timestamp: 1693678220888 }
      console.log(await rest.trade.setLeverage(3))
      
      // 3
      console.log(await (await rest.account.getInformation()).max_leverage)
      
      // Error: {"code":-1005,"message":"You can only choose the max leverage from 1 x to 10 x."}
      // @ts-ignore
      console.log(await rest.trade.setLeverage(7))
      
      // Argument of type '7' is not assignable to parameter of type 'LeverageType'.ts(2345)
      console.log(await rest.trade.setLeverage(6))
  }
)()
```

